### PR TITLE
mac compatibility for deleting node

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -133,7 +133,7 @@ $(function () {
   });
 
   $('html').keyup(function (e) {
-    if (e.keyCode == 46) {
+    if (e.keyCode == 46 || e.keyCode == 8) {
       cy.$(':selected').remove();
     }
   });


### PR DESCRIPTION
For macbook keyCode 46 is something else, and for backspace, we have the code 8. Therefore adding this to add delete functionality in mac.